### PR TITLE
Some games use plain "mono.dll"

### DIFF
--- a/Unispect/MainWindow.xaml
+++ b/Unispect/MainWindow.xaml
@@ -22,7 +22,7 @@
                 </Setter.Value>
             </Setter>
         </Style>
-        <Style x:Key="HyperlinkStyle" TargetType="{x:Type Hyperlink}" BasedOn="{StaticResource {x:Type Hyperlink}}"> 
+        <Style x:Key="HyperlinkStyle" TargetType="{x:Type Hyperlink}" BasedOn="{StaticResource {x:Type Hyperlink}}">
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
                     <!--<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />-->
@@ -48,7 +48,7 @@
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
     <mah:MetroWindow.RightWindowCommands>
-        <mah:WindowCommands> 
+        <mah:WindowCommands>
             <Button Click="BtnLoadPluginClick" Content="Load Plugin" ToolTip="Loads a plugin from the plugin list to use as the memory interface">
                 <Button.ContentTemplate>
                     <DataTemplate>
@@ -124,13 +124,13 @@
                 <!-- Left flyout (searchbox etc) -->
                 <StackPanel Margin="5,0,0,0">
                     <TextBlock>Search</TextBlock>
-                    <Grid Margin="0,0,0,5" Background="White" HorizontalAlignment="Left" VerticalAlignment="Top"  > 
+                    <Grid Margin="0,0,0,5" Background="White" HorizontalAlignment="Left" VerticalAlignment="Top"  >
                         <TextBlock Margin="0,4" Width="150" Text="Enter text here ..." 
                                    Foreground="LightSteelBlue" Visibility="{Binding ElementName=TxSearchBox, Path=Text.IsEmpty, 
                             Converter={StaticResource BoolToVisConverter}}" FontStyle="Italic" TextAlignment="Center" />
-                         
+
                         <TextBox TextChanged="TxSearchBox_OnTextChanged" Margin="0,0" Width="150" Name="TxSearchBox" Background="Transparent" Foreground="Black" CaretBrush="Black" />
- 
+
                         <Button  Width="20" Height="20" Foreground="White" Margin="125,0,0,0" HorizontalAlignment="Left"
                                  Style="{StaticResource TransparentStyle}" Click="BtnClearTextClick" 
                                  Visibility="{Binding ElementName=TxSearchBox, Path=Text.IsEmpty, 
@@ -149,8 +149,8 @@
                          Position="Bottom" Width="500" Height="220" CloseButtonVisibility="Visible" Background="{DynamicResource {x:Static SystemColors.HotTrackBrushKey}}" 
                          VerticalAlignment="Bottom"
                          Margin="0,0,0,0" AnimateOpacity="True" AnimateOnPositionChange="True" AreAnimationsEnabled="True">
-                <StackPanel HorizontalAlignment="Left"> 
-                    <TextBlock x:Name="TbTypeName"/>  
+                <StackPanel HorizontalAlignment="Left">
+                    <TextBlock x:Name="TbTypeName"/>
                     <TextBlock x:Name="TbOffset"/>
 
                     <TextBlock Margin="0,10,0,2">Fields</TextBlock>
@@ -169,11 +169,11 @@
     </mah:MetroWindow.Flyouts>
     <Grid>
         <Button x:Name="BtnDumpOffsets" Content="Go" HorizontalAlignment="Left" VerticalAlignment="Top" Width="102" Margin="682,17,0,0" Click="BtnDumpOffsets_Click" Height="53" FontSize="20"/>
-        <TextBox x:Name="TxLog" HorizontalAlignment="Left" Height="196" Margin="10,113,0,0"  VerticalAlignment="Top" Width="774" 
+        <TextBox x:Name="TxLog" HorizontalAlignment="Left" Height="175" Margin="10,134,0,0"  VerticalAlignment="Top" Width="774" 
                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Visible" IsReadOnly="True" />
-        <ProgressBar  Visibility="Hidden" x:Name="PbMain" HorizontalAlignment="Left" Height="22" Margin="10,86,0,0" VerticalAlignment="Top" Width="667" Maximum="1" SmallChange="0.001" LargeChange="0.1"/>
+        <ProgressBar  Visibility="Hidden" x:Name="PbMain" HorizontalAlignment="Left" Height="22" Margin="10,103,0,0" VerticalAlignment="Top" Width="667" Maximum="1" SmallChange="0.001" LargeChange="0.1"/>
         <Label Content="Output file" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="107"/>
-        <CheckBox x:Name="CkDumpToFile" Checked="CkDumpToFile_OnChecked" Unchecked="CkDumpToFile_OnChecked" Content="Save to file" HorizontalAlignment="Left" Margin="687,83,0,0" VerticalAlignment="Top" IsChecked="True"/>
+        <CheckBox x:Name="CkDumpToFile" Checked="CkDumpToFile_OnChecked" Unchecked="CkDumpToFile_OnChecked" Content="Save to file" HorizontalAlignment="Left" Margin="694,106,0,0" VerticalAlignment="Top" IsChecked="True"/>
         <Button Visibility="Hidden" x:Name="BtnShowInspector" HorizontalAlignment="Left" Margin="561,14,0,0" VerticalAlignment="Top" Width="116" Click="BtnShowInspector_OnClick" 
                 Content="Show Inspector"
                 ToolTip="Show the inspector view"/>
@@ -195,5 +195,9 @@
             Text="Assembly-CSharp"  
             ToolTip="This is the inspection's target assembly name. &#x0a;Leave it as Assembly-CSharp if you're unsure. "/>
         <Label Content="Target" HorizontalAlignment="Left" Margin="279,41,0,0" VerticalAlignment="Top" />
+        <TextBox x:Name="TxMonoModuleDll" HorizontalAlignment="Left" Height="23" Margin="117,72,0,0" VerticalAlignment="Top" Width="157"
+            Text="mono-2.0-bdwgc.dll"  
+            ToolTip="This is the inspection's target mono module. &#xA;Leave it as mono-2.0-bdwgc.dll if you're unsure. "/>
+        <Label Content="Mono Module" HorizontalAlignment="Left" Margin="10,72,0,0" VerticalAlignment="Top" Width="107"/>
     </Grid>
 </mah:MetroWindow>

--- a/Unispect/MainWindow.xaml.cs
+++ b/Unispect/MainWindow.xaml.cs
@@ -167,6 +167,7 @@ namespace Unispect
             var fileName = _dumpToFile ? TxOutputFile.Text : "";
             var processHandle = TxProcessHandle.Text;
             var moduleToDump = TxInspectorTarget.Text;
+            var monoModuleDll = TxMonoModuleDll.Text;
 
             bool exceptionOccurred = false;
             await Task.Run(() =>
@@ -181,7 +182,8 @@ namespace Unispect
                         fileName,
                         _memoryProxyType,
                         processHandle: processHandle,
-                        moduleToDump: moduleToDump);
+                        moduleToDump: moduleToDump,
+                        monoModuleName: monoModuleDll);
                 }
                 catch (Exception ex)
                 {

--- a/Unispect/Unispect.csproj
+++ b/Unispect/Unispect.csproj
@@ -45,13 +45,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
-      <HintPath>..\packages\ControlzEx.4.3.0\lib\net462\ControlzEx.dll</HintPath>
+      <HintPath>..\packages\ControlzEx.4.3.1\lib\net462\ControlzEx.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro, Version=2.0.0.0, Culture=neutral, PublicKeyToken=51482d6f650b2b3f, processorArchitecture=MSIL">
-      <HintPath>..\packages\MahApps.Metro.2.1.0\lib\net47\MahApps.Metro.dll</HintPath>
+      <HintPath>..\packages\MahApps.Metro.2.1.1\lib\net47\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro.IconPacks.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0c0d510f9915137a, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.IconPacks.Modern.4.2.0\lib\net47\MahApps.Metro.IconPacks.Core.dll</HintPath>
@@ -155,12 +155,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.6.0.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.0.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.6.0.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.0.0\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.2.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.2.0\build\Fody.targets'))" />
   </Target>
+  <Import Project="..\packages\Fody.6.2.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.2.0\build\Fody.targets')" />
 </Project>

--- a/Unispect/packages.config
+++ b/Unispect/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ControlzEx" version="4.3.0" targetFramework="net48" />
+  <package id="ControlzEx" version="4.3.1" targetFramework="net48" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net48" />
-  <package id="Fody" version="6.0.0" targetFramework="net48" developmentDependency="true" />
-  <package id="MahApps.Metro" version="2.1.0" targetFramework="net48" />
+  <package id="Fody" version="6.2.0" targetFramework="net48" developmentDependency="true" />
+  <package id="MahApps.Metro" version="2.1.1" targetFramework="net48" />
   <package id="MahApps.Metro.IconPacks.Modern" version="4.2.0" targetFramework="net48" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
As the title states, some games use plain "mono.dll" instead of "mono-2.0-bdwgc.dll", therefore having the choice to select targeted mono module would be a nice addition.